### PR TITLE
fix: reactor test failure

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1550,8 +1550,11 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 		return ErrInvalidProposalPOLRound
 	}
 
+	// If consensus does not enterNewRound yet, cs.Proposer may be nil or prior proposer, so don't use cs.Proposer
+	proposer := types.SelectProposer(cs.Validators, cs.state.LastProofHash, proposal.Height, proposal.Round)
+
 	// Verify signature
-	if !cs.Proposer.PubKey.VerifyBytes(proposal.SignBytes(cs.state.ChainID), proposal.Signature) {
+	if !proposer.PubKey.VerifyBytes(proposal.SignBytes(cs.state.ChainID), proposal.Signature) {
 		return ErrInvalidProposalSignature
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

After https://github.com/line/tendermint/pull/56, reactor_test often failed.
For example, `TestReactorValidatorSetChanges` test does not finish occasionally.

The reason is that when some peers receive proposal without starting the consensus, the thread was terminated by the nil pointer during the next processing.
```
func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
...
	// Verify signature
	if !cs.Proposer.PubKey.VerifyBytes(...) { // nil pointer referencing
		...
	}
...

}
```

We should not use cs.Proposer in this function.

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
