### PR TITLE
WIP: Fixing skipped testcase in replay

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -831,9 +831,14 @@ func (cs *State) enterNewRound(height int64, round int) {
 	prevProposer := cs.Proposer
 	cs.Proposer = types.SelectProposer(cs.Validators, cs.state.LastProofHash, height, round)
 	if prevProposer == nil || !bytes.Equal(prevProposer.Address, cs.Proposer.Address) {
-		logger.Info(fmt.Sprintf("Changing Proposer: %+v -> %+v", prevProposer, cs.Proposer))
+		prev := "nil"
+		if prevProposer != nil {
+			prev = fmt.Sprintf("%+v", prevProposer.PubKey.Address())
+		}
+		logger.Info(fmt.Sprintf("Changing Proposer: %+v -> [height=%d, round=%d] %+v",
+			prev, height, round, cs.Proposer.PubKey.Address()))
 	} else {
-		logger.Info(fmt.Sprintf("Current Proposer: %+v", cs.Proposer))
+		logger.Info(fmt.Sprintf("Current Proposer: %+v", cs.Proposer.PubKey.Address()))
 	}
 
 	// Setup new round


### PR DESCRIPTION
* `TestWALCrash`: the problem with SIGSEGV was due to the fact that Proposer is not selected in replay operation.
* Info-level logging is added when consensus state's Proposer changed.


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
