### PR TITLE
Optimizing imports

### DIFF
--- a/cmd/contract_tests/main.go
+++ b/cmd/contract_tests/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/snikch/goodman/hooks"
 	"github.com/snikch/goodman/transaction"
+
 	"github.com/tendermint/tendermint/cmd/contract_tests/unmarshaler"
 )
 

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -16,10 +17,6 @@ import (
 	"github.com/go-kit/kit/log/term"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto/vrf"
-
-	"path"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abcicli "github.com/tendermint/tendermint/abci/client"
@@ -28,6 +25,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
+	"github.com/tendermint/tendermint/crypto/vrf"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/herumi/bls-eth-go-binary/bls"
 	amino "github.com/tendermint/go-amino"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 )

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -3,18 +3,16 @@ package bls_test
 import (
 	"bytes"
 	"fmt"
-
 	"testing"
 
-	"github.com/tendermint/go-amino"
-	"github.com/tendermint/tendermint/crypto/ed25519"
-
 	b "github.com/herumi/bls-eth-go-binary/bls"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/go-amino"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/bls"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
 func TestPrivKeyBLS12_Bytes(t *testing.T) {

--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	coniksimpl "github.com/coniks-sys/coniks-go/crypto/vrf"
+
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 

--- a/crypto/vrf/vrf_coniks_test.go
+++ b/crypto/vrf/vrf_coniks_test.go
@@ -6,6 +6,7 @@ import (
 
 	coniksimpl "github.com/coniks-sys/coniks-go/crypto/vrf"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 

--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -4,6 +4,7 @@ package vrf
 
 import (
 	r2ishiguro "github.com/r2ishiguro/vrf/go/vrf_ed25519"
+
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 

--- a/crypto/vrf/vrf_test.go
+++ b/crypto/vrf/vrf_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/libs/rand"
-
 	dbm "github.com/tendermint/tm-db"
 
+	"github.com/tendermint/tendermint/libs/rand"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"

--- a/lite/commit.go
+++ b/lite/commit.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/tendermint/tendermint/crypto/vrf"
 
+	"github.com/tendermint/tendermint/crypto/vrf"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/lite/proxy/verifier.go
+++ b/lite/proxy/verifier.go
@@ -2,13 +2,12 @@ package proxy
 
 import (
 	"github.com/pkg/errors"
-	"github.com/tendermint/tendermint/types"
-
 	dbm "github.com/tendermint/tm-db"
 
 	log "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/lite"
 	lclient "github.com/tendermint/tendermint/lite/client"
+	"github.com/tendermint/tendermint/types"
 )
 
 func NewVerifier(

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -5,17 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tendermint/tendermint/crypto/ed25519"
-	"github.com/tendermint/tendermint/crypto/vrf"
-	"github.com/tendermint/tendermint/libs/rand"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/crypto/vrf"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/rand"
 	lite "github.com/tendermint/tendermint/lite2"
 	"github.com/tendermint/tendermint/lite2/provider"
 	mockp "github.com/tendermint/tendermint/lite2/provider/mock"

--- a/lite2/helpers_test.go
+++ b/lite2/helpers_test.go
@@ -3,13 +3,12 @@ package lite_test
 import (
 	"time"
 
-	"github.com/tendermint/tendermint/crypto/vrf"
-	"github.com/tendermint/tendermint/libs/rand"
-
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/tmhash"
+	"github.com/tendermint/tendermint/crypto/vrf"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 )

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/minio/highwayhash"
+
 	"github.com/tendermint/tendermint/crypto"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmrand "github.com/tendermint/tendermint/libs/rand"

--- a/privval/retry_signer_client.go
+++ b/privval/retry_signer_client.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tendermint/tendermint/crypto/vrf"
-
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/vrf"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -1,13 +1,14 @@
 package core
 
 import (
+	dbm "github.com/tendermint/tm-db"
+
 	cm "github.com/tendermint/tendermint/consensus"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 // Validators gets the validator set at the given block height.

--- a/types/block.go
+++ b/types/block.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tendermint/tendermint/crypto/vrf"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
+	"github.com/tendermint/tendermint/crypto/vrf"
 	"github.com/tendermint/tendermint/libs/bits"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmmath "github.com/tendermint/tendermint/libs/math"

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/types/voter_set.go
+++ b/types/voter_set.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/datastream/probab/dst"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	tmmath "github.com/tendermint/tendermint/libs/math"

--- a/types/voter_set_test.go
+++ b/types/voter_set_test.go
@@ -1,11 +1,12 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto/vrf"
 	tmtime "github.com/tendermint/tendermint/types/time"
 )


### PR DESCRIPTION
## Description

~~The current `*.pb.go` files in the `develop` branch consist of the import of the ProtocolBuffer as it was created by `make proto-gen`. But when we run `goimports -w .` after changing our files, a lot of `*.pb.go` files will appear with diffs that have nothing to do with the modification.~~

The current Tendermint version uses a `make format` instead of doing `gofmt` and `goimports`. In this case, the ProtocolBuffers' `*.pb.go` files are excluded from `goimports`. However, there seems still to be some difference in the result of `make format`, so I'll fix them with this PR instead of canceling.

This is PR for the purpose of cleaning up such the import statements.

1. `git checkout develop`
2. `make proto-gen`
3. `make proto-lint`
4. `make format`

There is no issue or ticket because this isn't a feature or behaviour modification, only have to care about the success of the tests.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
