### PR TITLE
fix: use voting power in MedianTime

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -192,8 +192,8 @@ func MedianTime(commit *types.Commit, voters *types.VoterSet) time.Time {
 		_, validator := voters.GetByAddress(commitSig.ValidatorAddress)
 		// If there's no condition, TestValidateBlockCommit panics; not needed normally.
 		if validator != nil {
-			totalVotingPower += validator.StakingPower
-			weightedTimes[i] = tmtime.NewWeightedTime(commitSig.Timestamp, validator.StakingPower)
+			totalVotingPower += validator.VotingPower
+			weightedTimes[i] = tmtime.NewWeightedTime(commitSig.Timestamp, validator.VotingPower)
 		}
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -23,6 +23,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
 // setupTestCase does setup common to all test cases.
@@ -1140,4 +1141,50 @@ func TestState_MakeHashMessage(t *testing.T) {
 	message3 := state.MakeHashMessage(0)
 	require.False(t, bytes.Equal(message1, message3))
 	require.False(t, bytes.Equal(message2, message3))
+}
+
+func TestMedianTime(t *testing.T) {
+	now := tmtime.Now()
+	cases := []struct {
+		votingPowers []int64
+		times        []time.Time
+		expectedMid  time.Time
+	}{
+		{
+			votingPowers: []int64{10, 10, 10, 10, 10}, // mid = 50/2 = 25
+			times:        []time.Time{now, now.Add(1), now.Add(2), now.Add(3), now.Add(4)},
+			expectedMid:  now.Add(2),
+		},
+		{
+			votingPowers: []int64{10, 20, 30, 40, 50}, // mid = 150/2 = 75
+			times:        []time.Time{now, now.Add(1), now.Add(2), now.Add(3), now.Add(4)},
+			expectedMid:  now.Add(3),
+		},
+		{
+			votingPowers: []int64{10, 20, 30, 40, 1000}, // mid = 1100/2 = 550
+			times:        []time.Time{now, now.Add(1), now.Add(2), now.Add(3), now.Add(4)},
+			expectedMid:  now.Add(4),
+		},
+		{
+			votingPowers: []int64{10, 2000, 2001, 2002, 2003}, // mid = 8016/2 = 4008
+			times:        []time.Time{now, now.Add(1), now.Add(2), now.Add(3), now.Add(4)},
+			expectedMid:  now.Add(2),
+		},
+	}
+
+	for i, tc := range cases {
+		vals := make([]*types.Validator, len(tc.times))
+		commits := make([]types.CommitSig, len(tc.times))
+		for j := range tc.votingPowers {
+			vals[j] = types.NewValidator(ed25519.GenPrivKey().PubKey(), 10)
+		}
+		voters := types.ToVoterAll(vals)
+		for j, power := range tc.votingPowers {
+			// reset voting power with a value that is not staking power
+			voters.Voters[j].VotingPower = power
+			commits[j] = types.NewCommitSigForBlock(rand.Bytes(10), voters.Voters[j].Address, tc.times[j])
+		}
+		commit := types.NewCommit(10, 0, types.BlockID{Hash: []byte("0xDEADBEEF")}, commits)
+		assert.True(t, sm.MedianTime(commit, voters) == tc.expectedMid, "case %d", i)
+	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
We are using `StakingPower` in `MedianTime` now.
We must use `VotingPower` instead of `StakingPower`.
This is not critical problem because block time is not verified in block verification for now.
But I fix it to follow the meaning of voting power.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [x] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
