### PR TITLE
add public-key type in sending ValidatorUpdate Tx

### DIFF
--- a/abci/example/kvstore/README.md
+++ b/abci/example/kvstore/README.md
@@ -22,7 +22,7 @@ and the Handshake allows any necessary blocks to be replayed.
 Validator set changes are effected using the following transaction format:
 
 ```
-"val:pubkey1!power1,pubkey2!power2,pubkey3!power3"
+"val:composite!pubkey1!power1,composite!pubkey2!power2,composite!pubkey3!power3"
 ```
 
 where `pubkeyN` is a base64-encoded 32-byte ed25519 key and `powerN` is a new voting power for the validator with `pubkeyN` (possibly a new one).


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

#107 
As a result of research, ValidatorUpdate Tx was used only in test, sample app.
Only one of the following places uses keytype.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
