### PR TITLE
feat: `txs_by_height` rpc api

### DIFF
--- a/lite2/rpc/client.go
+++ b/lite2/rpc/client.go
@@ -352,8 +352,8 @@ func (c *Client) TxSearch(query string, prove bool, page, perPage int, orderBy s
 	return c.next.TxSearch(query, prove, page, perPage, orderBy)
 }
 
-func (c *Client) TxByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
-	return c.next.TxByHeight(height, prove, orderBy)
+func (c *Client) TxsByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
+	return c.next.TxsByHeight(height, prove, orderBy)
 }
 
 // Validators fetches and verifies validators.

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -408,16 +408,16 @@ func (c *baseRPCClient) TxSearch(query string, prove bool, page, perPage int, or
 	return result, nil
 }
 
-func (c *baseRPCClient) TxByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
+func (c *baseRPCClient) TxsByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
 	result := new(ctypes.ResultTxSearch)
 	params := map[string]interface{}{
 		"height":   height,
 		"prove":    prove,
 		"order_by": orderBy,
 	}
-	_, err := c.caller.Call("tx_by_height", params, result)
+	_, err := c.caller.Call("txs_by_height", params, result)
 	if err != nil {
-		return nil, errors.Wrap(err, "TxByHeight")
+		return nil, errors.Wrap(err, "TxsByHeight")
 	}
 	return result, nil
 }

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -70,7 +70,7 @@ type SignClient interface {
 	Validators(height *int64, page, perPage int) (*ctypes.ResultValidators, error)
 	Tx(hash []byte, prove bool) (*ctypes.ResultTx, error)
 	TxSearch(query string, prove bool, page, perPage int, orderBy string) (*ctypes.ResultTxSearch, error)
-	TxByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error)
+	TxsByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error)
 }
 
 // HistoryClient provides access to data from genesis to now in large chunks.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -166,8 +166,8 @@ func (c *Local) TxSearch(query string, prove bool, page, perPage int, orderBy st
 	return core.TxSearch(c.ctx, query, prove, page, perPage, orderBy)
 }
 
-func (c *Local) TxByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
-	return core.TxByHeight(c.ctx, height, prove, orderBy)
+func (c *Local) TxsByHeight(height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
+	return core.TxsByHeight(c.ctx, height, prove, orderBy)
 }
 
 func (c *Local) BroadcastEvidence(ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -554,7 +554,7 @@ func TestTxSearch(t *testing.T) {
 	}
 }
 
-func TestTxByHeight(t *testing.T) {
+func TestTxsByHeight(t *testing.T) {
 	c := getHTTPClient()
 
 	heights := make([]int64, 10)
@@ -569,7 +569,7 @@ func TestTxByHeight(t *testing.T) {
 
 	// not prove and orderBy asc
 	for _, height := range heights {
-		res, err := c.TxByHeight(height, false, "asc")
+		res, err := c.TxsByHeight(height, false, "asc")
 		require.NoError(t, err)
 		require.Equal(t, 1, res.TotalCount)
 		require.Equal(t, 1, len(res.Txs))
@@ -577,7 +577,7 @@ func TestTxByHeight(t *testing.T) {
 
 	// prove and orderBy desc
 	for _, height := range heights {
-		res, err := c.TxByHeight(height, true, "desc")
+		res, err := c.TxsByHeight(height, true, "desc")
 		require.NoError(t, err)
 		require.Equal(t, 1, res.TotalCount)
 		require.Equal(t, 1, len(res.Txs))

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -25,7 +25,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"commit":               rpc.NewRPCFunc(Commit, "height"),
 	"tx":                   rpc.NewRPCFunc(Tx, "hash,prove"),
 	"tx_search":            rpc.NewRPCFunc(TxSearch, "query,prove,page,per_page,order_by"),
-	"tx_by_height":         rpc.NewRPCFunc(TxByHeight, "height,prove,order_by"),
+	"txs_by_height":        rpc.NewRPCFunc(TxsByHeight, "height,prove,order_by"),
 	"validators":           rpc.NewRPCFunc(Validators, "height,page,per_page"),
 	"dump_consensus_state": rpc.NewRPCFunc(DumpConsensusState, ""),
 	"consensus_state":      rpc.NewRPCFunc(ConsensusState, ""),

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -125,7 +125,7 @@ func TxSearch(ctx *rpctypes.Context, query string, prove bool, page, perPage int
 	return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
 }
 
-func TxByHeight(ctx *rpctypes.Context, height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
+func TxsByHeight(ctx *rpctypes.Context, height int64, prove bool, orderBy string) (*ctypes.ResultTxSearch, error) {
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
 		return nil, errors.New("transaction indexing is disabled")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related with: https://github.com/line/link/issues/1139

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* `blocks_and_tx_results` rest api calls `tx_search` rpc api and `tx_search`'s response size is limited by 100.
* `blocks_and_tx_results` calls `tx_search` rpc many times if a block has more than 100 txs.
  * Our performance target is 2000 txs in a block.
* `tx_search` searches txs and load all in the memory and slices it depending on a page. It's inefficient.
* So I'd like to introduce a new rpc api, `tx_by_height`.
* `tx_by_height` rpc api returns all txs in a block.
* `tx_by_height` could return more than 100 txs but the number of txs in a block is limited by `max_gas`.
* This api could help `Load Test` report processing time and also LBP pipelines' performance.

______

For contributor use:

- [x] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
