### PR TITLE
feat: Add GetSignKey on crypto

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -186,6 +186,10 @@ func (pubKey PubKeyBLS12) Address() crypto.Address {
 	return tmhash.SumTruncated(pubKey[:])
 }
 
+func (pubKey PubKeyBLS12) GetPubKey() crypto.PubKey {
+	return pubKey
+}
+
 // Bytes marshals the PubKey using amino encoding.
 func (pubKey PubKeyBLS12) Bytes() []byte {
 	bz, err := cdc.MarshalBinaryBare(pubKey)

--- a/crypto/composite/composite.go
+++ b/crypto/composite/composite.go
@@ -29,6 +29,10 @@ func (pk PubKeyComposite) Address() crypto.Address {
 	return crypto.Address(tmhash.SumTruncated(pk.Bytes()))
 }
 
+func (pk PubKeyComposite) GetPubKey() crypto.PubKey {
+	return pk.VrfKey
+}
+
 func (pk PubKeyComposite) Bytes() []byte {
 	msg := bytes.NewBuffer(pk.SignKey.Bytes())
 	msg.Write(pk.VrfKey.Bytes())

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -26,6 +26,7 @@ type Output []byte
 
 type PubKey interface {
 	Address() Address
+	GetPubKey() PubKey
 	Bytes() []byte
 	VerifyBytes(msg []byte, sig []byte) bool
 	VRFVerify(proof Proof, seed []byte) (Output, error)

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -151,6 +151,10 @@ func (pubKey PubKeyEd25519) Address() crypto.Address {
 	return crypto.Address(tmhash.SumTruncated(pubKey[:]))
 }
 
+func (pubKey PubKeyEd25519) GetPubKey() crypto.PubKey {
+	return pubKey
+}
+
 // Bytes marshals the PubKey using amino encoding.
 func (pubKey PubKeyEd25519) Bytes() []byte {
 	bz, err := cdc.MarshalBinaryBare(pubKey)

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -185,6 +185,7 @@ func (privkey testPriv) Equals(other crypto.PrivKey) bool { return true }
 type testPub []byte
 
 func (key testPub) Address() crypto.Address { return crypto.Address{} }
+func (key testPub) GetPubKey() crypto.PubKey { return key }
 func (key testPub) Bytes() []byte {
 	return testCdc.MustMarshalBinaryBare(key)
 }

--- a/crypto/multisig/threshold_pubkey.go
+++ b/crypto/multisig/threshold_pubkey.go
@@ -84,6 +84,10 @@ func (pk PubKeyMultisigThreshold) Address() crypto.Address {
 	return crypto.AddressHash(pk.Bytes())
 }
 
+func (pk PubKeyMultisigThreshold) GetPubKey() crypto.PubKey {
+	return pk
+}
+
 // Equals returns true iff pk and other both have the same number of keys, and
 // all constituent keys are the same, and in the same order.
 func (pk PubKeyMultisigThreshold) Equals(other crypto.PubKey) bool {

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -154,6 +154,10 @@ func (pubKey PubKeySecp256k1) Address() crypto.Address {
 	return crypto.Address(hasherRIPEMD160.Sum(nil))
 }
 
+func (pubKey PubKeySecp256k1) GetPubKey() crypto.PubKey {
+	return pubKey
+}
+
 // Bytes returns the pubkey marshalled with amino encoding.
 func (pubKey PubKeySecp256k1) Bytes() []byte {
 	bz, err := cdc.MarshalBinaryBare(pubKey)

--- a/crypto/sr25519/pubkey.go
+++ b/crypto/sr25519/pubkey.go
@@ -23,6 +23,10 @@ func (pubKey PubKeySr25519) Address() crypto.Address {
 	return crypto.Address(tmhash.SumTruncated(pubKey[:]))
 }
 
+func (pubKey PubKeySr25519) GetPubKey() crypto.PubKey {
+	return pubKey
+}
+
 // Bytes marshals the PubKey using amino encoding.
 func (pubKey PubKeySr25519) Bytes() []byte {
 	bz, err := cdc.MarshalBinaryBare(pubKey)

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -159,6 +159,7 @@ func TestABCIEvidence(t *testing.T) {
 type pubKeyEddie struct{}
 
 func (pubKeyEddie) Address() Address                                                { return []byte{} }
+func (pubKeyEddie) GetPubKey() crypto.PubKey                                        { return nil }
 func (pubKeyEddie) Bytes() []byte                                                   { return []byte{} }
 func (pubKeyEddie) VerifyBytes(msg []byte, sig []byte) bool                         { return false }
 func (pubKeyEddie) VRFVerify(proof crypto.Proof, msg []byte) (crypto.Output, error) { return nil, nil }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

line/link#1111

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Cosmos-SDK uses `pubkey`.
* https://github.com/line/cosmos-sdk/blob/develop/x/genutil/utils.go#L66

We want to use `ed25519.pubkey` or `composite.signkey.pubkey` in this line.
Therefore, we implement `GetSignKey`.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
