### PR TITLE
test: grpc_client_test and fix grpc_client `StopForError()` hang bug

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -88,11 +88,11 @@ func (cli *grpcClient) OnStop() {
 }
 
 func (cli *grpcClient) StopForError(err error) {
-	cli.mtx.Lock()
 	if !cli.IsRunning() {
 		return
 	}
 
+	cli.mtx.Lock()
 	if cli.err == nil {
 		cli.err = err
 	}

--- a/abci/client/grpc_client_test.go
+++ b/abci/client/grpc_client_test.go
@@ -1,0 +1,93 @@
+package abcicli_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abcicli "github.com/tendermint/tendermint/abci/client"
+	"github.com/tendermint/tendermint/abci/server"
+	"github.com/tendermint/tendermint/abci/types"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	"github.com/tendermint/tendermint/libs/service"
+)
+
+type errorStopper interface {
+	StopForError(error)
+}
+
+func TestSocketClientStopForErrorDeadlock(t *testing.T) {
+	c := abcicli.NewGRPCClient(":80", false).(errorStopper)
+	err := errors.New("foo-tendermint")
+
+	// See Issue https://github.com/tendermint/abci/issues/114
+	doneChan := make(chan bool)
+	go func() {
+		defer close(doneChan)
+		c.StopForError(err)
+		c.StopForError(err)
+	}()
+
+	select {
+	case <-doneChan:
+	case <-time.After(time.Second * 4):
+		t.Fatalf("Test took too long, potential deadlock still exists")
+	}
+}
+
+func TestProperSyncCalls(t *testing.T) {
+	app := slowApp{}
+
+	s, c := setupClientServer(t, app)
+	defer s.Stop()
+	defer c.Stop()
+
+	resp := make(chan error, 1)
+	go func() {
+		// This is BeginBlockSync unrolled....
+		reqres := c.BeginBlockAsync(types.RequestBeginBlock{})
+		c.FlushSync()
+		res := reqres.Response.GetBeginBlock()
+		require.NotNil(t, res)
+		resp <- c.Error()
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		require.Fail(t, "No response arrived")
+	case err, ok := <-resp:
+		require.True(t, ok, "Must not close channel")
+		assert.NoError(t, err, "This should return success")
+	}
+}
+
+func setupClientServer(t *testing.T, app types.Application) (
+	service.Service, abcicli.Client) {
+	// some port between 20k and 30k
+	port := 20000 + tmrand.Int32()%10000
+	addr := fmt.Sprintf("localhost:%d", port)
+
+	s, err := server.NewServer(addr, "grpc", app)
+	require.NoError(t, err)
+	err = s.Start()
+	require.NoError(t, err)
+
+	c := abcicli.NewGRPCClient(addr, true)
+	err = c.Start()
+	require.NoError(t, err)
+
+	return s, c
+}
+
+type slowApp struct {
+	types.BaseApplication
+}
+
+func (slowApp) BeginBlock(req types.RequestBeginBlock) types.ResponseBeginBlock {
+	time.Sleep(200 * time.Millisecond)
+	return types.ResponseBeginBlock{}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related with: #153, https://github.com/line/link/issues/1150

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Within #153, I've removed abci socket implementation and `abci/client/socket_client_test.go`. In `socket_client_test.go`, it has 3 test cases and 2 cases among these are valid for `grpc_client`. There wasn't `grpc_client_test.go` so I recover `socket_client_test.go` as `grpc_client_test.go`. With this test, I found grpc_client has hanging bug that is already fixed within socket client.

Bugfix Reference: https://github.com/line/tendermint/blob/a01efd28c7257d3b056d1fcf263d39ccea3c1273/abci/client/socket_client.go#L94-L107
______

For contributor use:

- [x] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
