### PR TITLE
fix: error handling after check tx

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -329,7 +329,13 @@ func (mem *CListMempool) reqResCb(
 			panic("recheck cursor is not nil in reqResCb")
 		}
 
-		mem.resCbFirstTime(tx, peerID, peerP2PID, res)
+		err := mem.resCbFirstTime(tx, peerID, peerP2PID, res)
+		if err != nil {
+			if externalCb != nil {
+				externalCb(abci.ToResponseException(err.Error()))
+			}
+			return
+		}
 
 		// update metrics
 		mem.metrics.Size.Set(float64(mem.Size()))
@@ -389,11 +395,11 @@ func (mem *CListMempool) resCbFirstTime(
 	peerID uint16,
 	peerP2PID p2p.ID,
 	res *abci.Response,
-) {
+) error {
 	switch r := res.Value.(type) {
 	case *abci.Response_CheckTx:
 		var postCheckErr error
-		if mem.postCheck != nil {
+		if (r.CheckTx.Code == abci.CodeTypeOK) && mem.postCheck != nil {
 			postCheckErr = mem.postCheck(tx, r.CheckTx)
 		}
 		if (r.CheckTx.Code == abci.CodeTypeOK) && postCheckErr == nil {
@@ -403,7 +409,7 @@ func (mem *CListMempool) resCbFirstTime(
 				// remove from cache (mempool might have a space later)
 				mem.cache.Remove(tx)
 				mem.logger.Error(err.Error())
-				return
+				return err
 			}
 
 			memTx := &mempoolTx{
@@ -427,10 +433,13 @@ func (mem *CListMempool) resCbFirstTime(
 			mem.metrics.FailedTxs.Add(1)
 			// remove from cache (it might be good later)
 			mem.cache.Remove(tx)
+			return postCheckErr
 		}
 	default:
 		// ignore other messages
 	}
+
+	return nil
 }
 
 // callback, which is called after the app rechecked the tx.

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -41,6 +41,10 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 		return nil, err
 	}
 	res := <-resCh
+	except := res.GetException()
+	if except != nil {
+		return nil, fmt.Errorf(except.Error)
+	}
 	r := res.GetCheckTx()
 	return &ctypes.ResultBroadcastTx{
 		Code:      r.Code,
@@ -84,6 +88,11 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 		return nil, fmt.Errorf("error on broadcastTxCommit: %v", err)
 	}
 	checkTxResMsg := <-checkTxResCh
+	checkTxExcept := checkTxResMsg.GetException()
+	if checkTxExcept != nil {
+		env.Logger.Error("Error on broadcastTxCommit", "err", checkTxExcept.Error)
+		return nil, fmt.Errorf("error on broadcastTxCommit: %v", checkTxExcept.Error)
+	}
 	checkTxRes := checkTxResMsg.GetCheckTx()
 	if checkTxRes.Code != abci.CodeTypeOK {
 		return &ctypes.ResultBroadcastTxCommit{


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Related with: https://github.com/line/link/issues/1153, https://github.com/tendermint/tendermint/issues/5675, https://github.com/tendermint/tendermint/issues/3546

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

There is no error handling after `checkTx` is done. If we got an error after `checkTx`, this error is not propagated at all. In this case, a tx could be missed even though the client gets the success response. I revise just to propagate an error.

We need to revise `cosmos-sdk` as well especially on handling `tendermint` error after broadcasting a tx.

https://github.com/line/cosmos-sdk/blob/fd6d941cc429fc2a58154dbace3bbaec4beef445/client/context/broadcast.go#L37-L49

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
