### PR TITLE
fix: change bytes-codec to amino-codec

### DIFF
--- a/crypto/composite/composite.go
+++ b/crypto/composite/composite.go
@@ -1,8 +1,7 @@
 package composite
 
 import (
-	"bytes"
-
+	"github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/bls"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -15,6 +14,25 @@ const (
 	PubKeyCompositeAminoName  = "tendermint/PubKeyComposite"
 	PrivKeyCompositeAminoName = "tendermint/PrivKeyComposite"
 )
+
+var cdc = amino.NewCodec()
+
+func init() {
+	cdc.RegisterInterface((*crypto.PubKey)(nil), nil)
+	cdc.RegisterConcrete(PubKeyComposite{},
+		PubKeyCompositeAminoName, nil)
+	cdc.RegisterConcrete(bls.PubKeyBLS12{},
+		bls.PubKeyAminoName, nil)
+	cdc.RegisterConcrete(ed25519.PubKeyEd25519{},
+		ed25519.PubKeyAminoName, nil)
+	cdc.RegisterInterface((*crypto.PrivKey)(nil), nil)
+	cdc.RegisterConcrete(PrivKeyComposite{},
+		PrivKeyCompositeAminoName, nil)
+	cdc.RegisterConcrete(bls.PrivKeyBLS12{},
+		bls.PrivKeyAminoName, nil)
+	cdc.RegisterConcrete(ed25519.PrivKeyEd25519{},
+		ed25519.PrivKeyAminoName, nil)
+}
 
 type PubKeyComposite struct {
 	SignKey crypto.PubKey `json:"sign"`
@@ -30,9 +48,11 @@ func (pk PubKeyComposite) Address() crypto.Address {
 }
 
 func (pk PubKeyComposite) Bytes() []byte {
-	msg := bytes.NewBuffer(pk.SignKey.Bytes())
-	msg.Write(pk.VrfKey.Bytes())
-	return msg.Bytes()
+	bz, err := cdc.MarshalBinaryBare(pk)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 func (pk PubKeyComposite) VerifyBytes(msg []byte, sig []byte) bool {
@@ -67,7 +87,7 @@ func (sk PrivKeyComposite) Identity() crypto.PrivKey {
 }
 
 func (sk PrivKeyComposite) Bytes() []byte {
-	return sk.Identity().Bytes()
+	return cdc.MustMarshalBinaryBare(sk)
 }
 
 func (sk PrivKeyComposite) Sign(msg []byte) ([]byte, error) {

--- a/crypto/composite/composite_test.go
+++ b/crypto/composite/composite_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/tendermint/go-amino"
@@ -253,7 +254,7 @@ func TestEnvironmentalCompatibility(t *testing.T) {
 		// compare addresses to assumed value
 		compositePrivKey := composite.NewPrivKeyComposite(blsPrivKey, ed25519PrivKey)
 		compositePubKey := compositePrivKey.PubKey()
-		address, err := hex.DecodeString("7A68265205CB115AE35A13515C423F1721E87BB4")
+		address, err := hex.DecodeString(strings.ToUpper("72dd758835404175940f698cf3ddc29dd0d04afa"))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
In Tendermint, the public key is specified to use amino encode. See below for details.
https://github.com/line/tendermint/blob/develop/docs/architecture/adr-015-crypto-encoding.md

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
