### PR TITLE
test: don't use foo-bar.net in TestHTTPClientMakeHTTPDialer

### DIFF
--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -1,23 +1,36 @@
 package client
 
 import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80", "https://user:pass@foo-bar.net:80"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hi!\n"))
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
 
-	for _, f := range remote {
-		u, err := newParsedURL(f)
+	tsTLS := httptest.NewTLSServer(handler)
+	defer tsTLS.Close()
+	// This silences a TLS handshake error, caused by the dialer just immediately
+	// disconnecting, which we can just ignore.
+	tsTLS.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+	for _, testURL := range []string{ts.URL, tsTLS.URL} {
+		u, err := newParsedURL(testURL)
 		require.NoError(t, err)
-		dialFn, err := makeHTTPDialer(f)
+		dialFn, err := makeHTTPDialer(testURL)
 		require.Nil(t, err)
 
 		addr, err := dialFn(u.Scheme, u.GetHostWithPath())
 		require.NoError(t, err)
 		require.NotNil(t, addr)
 	}
-
 }


### PR DESCRIPTION
## Description
CI fails because of test relied on connecting to the external site.
So cherry-pick https://github.com/tendermint/tendermint/pull/5997


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
