### PR TITLE
test: don't use foo-bar.net in TestHTTPClientMakeHTTPDialer (#5997)

### DIFF
--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -1,23 +1,36 @@
 package client
 
 import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80", "https://user:pass@foo-bar.net:80"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hi!\n"))
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
 
-	for _, f := range remote {
-		u, err := newParsedURL(f)
+	tsTLS := httptest.NewTLSServer(handler)
+	defer tsTLS.Close()
+	// This silences a TLS handshake error, caused by the dialer just immediately
+	// disconnecting, which we can just ignore.
+	tsTLS.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+	for _, testURL := range []string{ts.URL, tsTLS.URL} {
+		u, err := newParsedURL(testURL)
 		require.NoError(t, err)
-		dialFn, err := makeHTTPDialer(f)
+		dialFn, err := makeHTTPDialer(testURL)
 		require.Nil(t, err)
 
 		addr, err := dialFn(u.Scheme, u.GetHostWithPath())
 		require.NoError(t, err)
 		require.NotNil(t, addr)
 	}
-
 }


### PR DESCRIPTION
See: https://github.com/line/tendermint/pull/173

CI fails because of test relied on connecting to the external site.
So cherry-pick tendermint/tendermint#5997

https://github.com/tendermint/tendermint/commit/f54f80bf0d464ffec6facf98e447ee403bbf1e8c
> git cherry-pick f54f80bf0d464ffec6facf98e447ee403bbf1e8c

## Quatation

This test relied on connecting to the external site `foo-bar.net`, and (predictably) the site went down and broke all of our CI runs. This changes it to use local HTTP servers instead.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [x] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
