### PR TITLE
feat: Add total block size for prometheus

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -56,6 +56,8 @@ type Metrics struct {
 	BlockSizeBytes metrics.Gauge
 	// Total number of transactions.
 	TotalTxs metrics.Gauge
+	// Total byte-size of blocks.
+	TotalBlockSizeBytes metrics.Counter
 	// The latest block height.
 	CommittedHeight metrics.Gauge
 	// Whether or not a node is fast syncing. 1 if yes, 0 if no.
@@ -197,6 +199,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "total_txs",
 			Help:      "Total number of transactions.",
 		}, labels).With(labelsAndValues...),
+		TotalBlockSizeBytes: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "total_block_size_bytes",
+			Help:      "Total byte-size of blocks since process startup.",
+		}, labels).With(labelsAndValues...),
 		CommittedHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -323,12 +331,13 @@ func NopMetrics() *Metrics {
 
 		BlockIntervalSeconds: discard.NewGauge(),
 
-		NumTxs:          discard.NewGauge(),
-		BlockSizeBytes:  discard.NewGauge(),
-		TotalTxs:        discard.NewGauge(),
-		CommittedHeight: discard.NewGauge(),
-		FastSyncing:     discard.NewGauge(),
-		BlockParts:      discard.NewCounter(),
+		NumTxs:              discard.NewGauge(),
+		BlockSizeBytes:      discard.NewGauge(),
+		TotalTxs:            discard.NewGauge(),
+		TotalBlockSizeBytes: discard.NewCounter(),
+		CommittedHeight:     discard.NewGauge(),
+		FastSyncing:         discard.NewGauge(),
+		BlockParts:          discard.NewCounter(),
 
 		MissingProposal: discard.NewGauge(),
 		RoundFailures:   discard.NewHistogram(),

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1680,6 +1680,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.NumTxs.Set(float64(len(block.Data.Txs)))
 	cs.metrics.TotalTxs.Add(float64(len(block.Data.Txs)))
 	cs.metrics.BlockSizeBytes.Set(float64(block.Size()))
+	cs.metrics.TotalBlockSizeBytes.Add(float64(block.Size()))
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 
 	cs.metrics.RoundFailures.Observe(float64(cs.Round))

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
- 
+
 make build-docker
-LINE_VERSION="$(awk -F\" '/LINECoreSemVer =/ {print $2; exit }' < ./version/version.go)"
+TM_VERSION="$(awk -F\" '/TMCoreSemVer *=/ {print $2; exit }' < ./version/version.go)"
+LINE_VERSION="$(awk -F\" '/LINECoreSemVer *=/ {print $2; exit }' < ./version/version.go)"
+DATE_VERSION="`date "+%y%m%d"`"
 GIT_COMMIT="$(git rev-parse --short=8 HEAD)"
-TAG=docker-registry.linecorp.com/link-network/tendermint:latest
-docker tag tendermint/tendermint:latest $TAG
- 
-read -p "==> Do you push docker image to [$TAG]? (y/n) " -n 1 -r
+TAG=${TM_VERSION}_${LINE_VERSION}-${DATE_VERSION}-${GIT_COMMIT}
+docker tag tendermint/tendermint:latest docker-registry.linecorp.com/link-network/tendermint:$TAG
+echo "New tendermint version: $TAG"
+
+read -p "==> Do you push docker image to repository as [$TAG]? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker push $TAG
+    docker push docker-registry.linecorp.com/link-network/tendermint:latest
+    docker push docker-registry.linecorp.com/link-network/tendermint:$TAG
 fi
 

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/bls"
 	"github.com/tendermint/tendermint/crypto/composite"

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	amino "github.com/tendermint/go-amino"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/libs/rand"


### PR DESCRIPTION
Closes: #XXX

## Description

This PR is a performance test fix that includes the following two points:

* Added a `total_block_size_bytes` to Prometheus to calculate the average size of blocks.
* Enabled to push/pull Docker images with the build-time version instead of the latest.

______

For contributor use:

- [x] ~Wrote tests~
- [x] ~Updated CHANGELOG_PENDING.md~
- [x] ~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~
- [x] ~Updated relevant documentation (`docs/`) and code comments~
- [x] ~Re-reviewed `Files changed` in the Github PR explorer~
