### PR TITLE
feat: add an option for selecting priv key type to `unsafe_reset_all`, `unsafe_reset_priv_validator`, and `gen_validator`

### DIFF
--- a/cmd/tendermint/commands/gen_validator.go
+++ b/cmd/tendermint/commands/gen_validator.go
@@ -16,8 +16,13 @@ var GenValidatorCmd = &cobra.Command{
 	Run:   genValidator,
 }
 
+func init() {
+	GenValidatorCmd.Flags().String("priv_key_type", config.PrivKeyType,
+		"Specify validator's private key type (ed25519 | composite)")
+}
+
 func genValidator(cmd *cobra.Command, args []string) {
-	pv, _ := privval.GenFilePV("", "", privval.PrivKeyTypeEd25519)
+	pv, _ := privval.GenFilePV("", "", config.PrivKeyType)
 	jsbz, err := cdc.MarshalJSON(pv)
 	if err != nil {
 		panic(err)

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -22,6 +22,10 @@ var keepAddrBook bool
 
 func init() {
 	ResetAllCmd.Flags().BoolVar(&keepAddrBook, "keep-addr-book", false, "Keep the address book intact")
+	ResetAllCmd.Flags().String("priv_key_type", config.PrivKeyType,
+		"Specify validator's private key type (ed25519 | composite)")
+	ResetPrivValidatorCmd.Flags().String("priv_key_type", config.PrivKeyType,
+		"Specify validator's private key type (ed25519 | composite)")
 }
 
 // ResetPrivValidatorCmd resets the private validator files.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Ref: https://github.com/line/tendermint/pull/125

## Description

The purpose is the same as this PR.
Specifically, the value specified in the option `--priv_key_type=composite` is used as an argument of this function `GenFilePV(privValKeyFile, privValStateFile, privKeyType)`. Therefore, the same option must be added to the command calling this function `GenFilePV(privValKeyFile, privValStateFile, privKeyType)`.
The following command added the option:
- gen_validator
- unsafe_reset_all
- unsafe_reset_priv_validator

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [x] ~Wrote tests~
- [x] ~Updated CHANGELOG_PENDING.md~
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] ~Updated relevant documentation (`docs/`) and code comments~
- [ ] Re-reviewed `Files changed` in the Github PR explorer
