### PR TITLE
Add a test case to confirm that the selected Proposer matches the VRF-selected one

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1096,14 +1096,14 @@ func (cs *State) createProposalBlock(round int) (block *types.Block, blockParts 
 	if cs.privValidator == nil {
 		panic("entered createProposalBlock with privValidator being nil")
 	}
-	_, err := cs.privValidator.GetPubKey()
+	pubKey, err := cs.privValidator.GetPubKey()
 	if err != nil {
 		// If this node is a validator & proposer in the current round, it will
 		// miss the opportunity to create a block.
 		cs.Logger.Error("Error on retrival of pubkey", "err", err)
 		return
 	}
-	proposerAddr := cs.Validators.SelectProposer(cs.state.LastProofHash, cs.Height, round).Address
+	proposerAddr := pubKey.Address()
 	message := cs.state.MakeHashMessage(round)
 
 	proof, err := cs.privValidator.GenerateVRFProof(message)


### PR DESCRIPTION
## Description

This PR adds an assertion that confirms that the Proposer selected by the common function in test cases exactly matches the one selected by VRF.

As you can see in the commit history, I've reverted the original fix, but the additional test case may be useful, so I'll leave it.

______

For contributor use:

- [x] Wrote tests
- [x] ~Updated CHANGELOG_PENDING.md~
- [x] ~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~
- [x] ~Updated relevant documentation (`docs/`) and code comments~
- [x] Re-reviewed `Files changed` in the Github PR explorer
