### PR TITLE
chore: remove hard coded codecov token

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  token: a0d06f00-e140-4525-93f9-1722b2c9d5d2
-
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX
We have an issue about token security: https://about.codecov.io/security-update/
We should regenerate all token used in scripts running ci.
And we must not use hard-coded token in a script like this.
I regenerated a new upload token in codecov, and added that variable to `circleci` environment variables.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
