### PR TITLE
build: remove needless build tag `!libsecp256k1`

### DIFF
--- a/crypto/secp256k1/secp256k1_nocgo.go
+++ b/crypto/secp256k1/secp256k1_nocgo.go
@@ -1,5 +1,3 @@
-// +build !libsecp256k1
-
 package secp256k1
 
 import (


### PR DESCRIPTION
## Description

Removes the needless build tag `!libsecp256k1`.
The build tag makes disable go implementation of secp256k1.
Cause there is no C implementation, a build error will occur when using tag `libsecp256k1`.

related to: line/lbm-sdk#173

