### PR TITLE
feat: add duration metrics of gauge type

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -79,6 +79,14 @@ type Metrics struct {
 	DurationCommitCommitting   metrics.Histogram
 	DurationCommitRechecking   metrics.Histogram
 	DurationWaitingForNewRound metrics.Histogram
+
+	DurationGaugeProposal           metrics.Gauge
+	DurationGaugePrevote            metrics.Gauge
+	DurationGaugePrecommit          metrics.Gauge
+	DurationGaugeCommitExecuting    metrics.Gauge
+	DurationGaugeCommitCommitting   metrics.Gauge
+	DurationGaugeCommitRechecking   metrics.Gauge
+	DurationGaugeWaitingForNewRound metrics.Gauge
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -267,6 +275,48 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Duration of waiting for next new round",
 			Buckets:   stdprometheus.LinearBuckets(100, 100, 10),
 		}, labels).With(labelsAndValues...),
+		DurationGaugeProposal: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_proposal",
+			Help:      "Duration of proposal step",
+		}, labels).With(labelsAndValues...),
+		DurationGaugePrevote: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_prevote",
+			Help:      "Duration of prevote step",
+		}, labels).With(labelsAndValues...),
+		DurationGaugePrecommit: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_precommit",
+			Help:      "Duration of precommit step",
+		}, labels).With(labelsAndValues...),
+		DurationGaugeCommitExecuting: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_commit_executing",
+			Help:      "Duration of executing block txs",
+		}, labels).With(labelsAndValues...),
+		DurationGaugeCommitCommitting: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_commit_committing",
+			Help:      "Duration of committing updated state",
+		}, labels).With(labelsAndValues...),
+		DurationGaugeCommitRechecking: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_commit_rechecking",
+			Help:      "Duration of rechecking mempool txs",
+		}, labels).With(labelsAndValues...),
+		DurationGaugeWaitingForNewRound: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duration_gauge_waiting_for_new_round",
+			Help:      "Duration of waiting for next new round",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -308,5 +358,13 @@ func NopMetrics() *Metrics {
 		DurationCommitCommitting:   discard.NewHistogram(),
 		DurationCommitRechecking:   discard.NewHistogram(),
 		DurationWaitingForNewRound: discard.NewHistogram(),
+
+		DurationGaugeProposal:           discard.NewGauge(),
+		DurationGaugePrevote:            discard.NewGauge(),
+		DurationGaugePrecommit:          discard.NewGauge(),
+		DurationGaugeCommitExecuting:    discard.NewGauge(),
+		DurationGaugeCommitCommitting:   discard.NewGauge(),
+		DurationGaugeCommitRechecking:   discard.NewGauge(),
+		DurationGaugeWaitingForNewRound: discard.NewGauge(),
 	}
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1853,6 +1853,14 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.DurationCommitCommitting.Observe(cs.stepTimes.CommitCommitting.GetDuration())
 	cs.metrics.DurationCommitRechecking.Observe(cs.stepTimes.CommitRechecking.GetDuration())
 	cs.metrics.DurationWaitingForNewRound.Observe(cs.stepTimes.WaitingForNewRound.GetDuration())
+
+	cs.metrics.DurationGaugeProposal.Set(cs.stepTimes.Proposal.GetDuration())
+	cs.metrics.DurationGaugePrevote.Set(cs.stepTimes.Prevote.GetDuration())
+	cs.metrics.DurationGaugePrecommit.Set(cs.stepTimes.Precommit.GetDuration())
+	cs.metrics.DurationGaugeCommitExecuting.Set(cs.stepTimes.CommitExecuting.GetDuration())
+	cs.metrics.DurationGaugeCommitCommitting.Set(cs.stepTimes.CommitCommitting.GetDuration())
+	cs.metrics.DurationGaugeCommitRechecking.Set(cs.stepTimes.CommitRechecking.GetDuration())
+	cs.metrics.DurationGaugeWaitingForNewRound.Set(cs.stepTimes.WaitingForNewRound.GetDuration())
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
We need gauge type metrics, such as the ones we added in the previous PR(https://github.com/line/ostracon/pull/229).
These are required for `grafana` charts.

```
ostracon_consensus_duration_gauge_commit_committing{chain_id="test-chain-sOI8kc"} 0.047
ostracon_consensus_duration_gauge_commit_executing{chain_id="test-chain-sOI8kc"} 24.821
ostracon_consensus_duration_gauge_commit_rechecking{chain_id="test-chain-sOI8kc"} 26.007
ostracon_consensus_duration_gauge_precommit{chain_id="test-chain-sOI8kc"} 74.222
ostracon_consensus_duration_gauge_prevote{chain_id="test-chain-sOI8kc"} 46.62
ostracon_consensus_duration_gauge_proposal{chain_id="test-chain-sOI8kc"} 78.721
ostracon_consensus_duration_gauge_waiting_for_new_round{chain_id="test-chain-sOI8kc"} 900.399
```

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

Closes: #XXX

