### PR TITLE
perf: build merkle root hash in parallel

### DIFF
--- a/crypto/merkle/tree_bench_test.go
+++ b/crypto/merkle/tree_bench_test.go
@@ -1,0 +1,34 @@
+package merkle
+
+import (
+	"testing"
+
+	"github.com/line/ostracon/crypto/tmhash"
+	tmrand "github.com/line/ostracon/libs/rand"
+)
+
+func BenchmarkHashFromByteSlices(b *testing.B) {
+	const total = 4000
+	slices := make([][]byte, total)
+	for j := 0; j < total; j++ {
+		slices[j] = tmrand.Bytes(tmhash.Size)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		HashFromByteSlices(slices)
+	}
+}
+
+func BenchmarkHashFromByteSlicesParallel(b *testing.B) {
+	const total = 4000
+	slices := make([][]byte, total)
+	for j := 0; j < total; j++ {
+		slices[j] = tmrand.Bytes(tmhash.Size)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		HashFromByteSlicesParallel(slices, 0)
+	}
+}

--- a/types/tx_bench_test.go
+++ b/types/tx_bench_test.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"testing"
+)
+
+func BenchmarkTx_Hash(b *testing.B) {
+	const (
+		total = 4000
+		size  = 300
+	)
+	txs := makeTxs(total, size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txs.Hash()
+	}
+}


### PR DESCRIPTION
## Description


## Benchmarks
### HashFromByteSlices
`go test ./crypto/merkle -bench=BenchmarkHashFromByteSlices --test.benchtime=5s`
```
BenchmarkHashFromByteSlices-12                      2101           2878782 ns/op
BenchmarkHashFromByteSlicesParallel-12              6958           1013022 ns/op
```

### Tx.Hash()
`go test ./types -bench=BenchmarkTx_Hash --test.benchtime=5s`

**AS-IS**
```
BenchmarkTx_Hash-12          957           6183750 ns/op
```

**TO-BE**
```
BenchmarkTx_Hash-12         2133           3210047 ns/op
```
