### PR TITLE
perf: do not flush wal when receive consensus msgs

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -816,15 +816,6 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			if err := cs.wal.Write(mi); err != nil {
 				cs.Logger.Error("failed writing to WAL", "err", err)
 			}
-			go func() {
-				if err := cs.wal.FlushAndSync(); err != nil {
-					cs.Logger.Error("CONSENSUS FAILURE!!!", "err", fmt.Sprintf(
-						"failed to write %v msg to consensus WAL due to %v; check your file system and restart the node",
-						mi, err,
-					), "stack", string(debug.Stack()))
-					onExit(cs)
-				}
-			}()
 
 			if _, ok := mi.Msg.(*VoteMessage); ok {
 				// we actually want to simulate failing during


### PR DESCRIPTION
## Description
There is a performance degradation in the proposal step, because WAL is flushed too often by `BlockPartMessage`.
But no disk write occurs until signVote, so there is no need to flush until then.
So I fix to not flush wal when receive consensus msgs.


## Consensus Steps
**AS-IS**
```
**** total average **** 
  proposal: 344.37994
  prevote: 11.697058
  precommit: 25.168762
  commit executing: 1007.19324
  commit committing: 49.402355
  commit rechecking: 339.38562
  waiting for new round: 22.440947
  block interval: 1764.7059
  TPS: 2377.2666
```

**TO-BE**
```
**** total average **** 
  proposal: 105.87284
  prevote: 13.862401
  precommit: 19.146082
  commit executing: 737.93524
  commit committing: 36.59688
  commit rechecking: 200.36572
  waiting for new round: 71.28
  block interval: 1200.0
  TPS: 3239.6
```