### PR TITLE
Update dependabot.yml: Remove npm for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,6 @@ updates:
       interval: daily
       time: "11:00"
     open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/docs"
-    schedule:
-      interval: daily
-      time: "11:00"
-    open-pull-requests-limit: 10
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
We are no longer using npm
