### PR TITLE
update types/part_set.go

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -165,7 +165,7 @@ type PartSet struct {
 // The data bytes are split into "partSize" chunks, and merkle tree computed.
 // CONTRACT: partSize is greater than zero.
 func NewPartSetFromData(data []byte, partSize uint32) *PartSet {
-	// divide data into 4kb parts.
+	// divide data into parts of size `partSize`
 	total := (uint32(len(data)) + partSize - 1) / partSize
 	parts := make([]*Part, total)
 	partsBytes := make([][]byte, total)


### PR DESCRIPTION
Hi, I'm looking at the ostracon code and came across the annotation that I found awkward.
I found that the same comment is described not only in ostracon but also in cometBFT, so I changed cometBFT first and my proposal was approved.
Here is the related link: https://github.com/cometbft/cometbft/pull/1056

In `types/params.go`, the value of BlockPartSizeBytes is 65536 (about 64kB). 
In the function ```func NewPartSetFromData(data []byte, partSize uint32) *PartSet``` in `types/part_set.go`, the function uses the parameter `partSize` which is the value of BlockPartSizeBytes.
However, the annotation says it's 4kB, so I'm doing a pull request to fix it.