### PR TITLE
Use tendermint application interface

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -262,7 +262,7 @@ func (app *localClient) CheckTxSync(req types.RequestCheckTx) (*types.ResponseCh
 	// app.mtx.Lock()
 	// defer app.mtx.Unlock()
 
-	res := app.Application.CheckTxSync(req)
+	res := app.Application.CheckTx(req)
 	return &res, nil
 }
 

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -81,7 +81,7 @@ func (app *PersistentKVStoreApplication) DeliverTx(req types.RequestDeliverTx) t
 	return app.app.DeliverTx(req)
 }
 
-func (app *PersistentKVStoreApplication) CheckTxSync(req types.RequestCheckTx) types.ResponseCheckTx {
+func (app *PersistentKVStoreApplication) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
 	return app.app.CheckTxSync(req)
 }
 

--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -207,7 +207,7 @@ func (s *SocketServer) handleRequest(req *types.Request, responses chan<- *types
 		res := s.app.DeliverTx(*r.DeliverTx)
 		responses <- types.ToResponseDeliverTx(res)
 	case *types.Request_CheckTx:
-		res := s.app.CheckTxSync(*r.CheckTx)
+		res := s.app.CheckTx(*r.CheckTx)
 		responses <- types.ToResponseCheckTx(res)
 	case *types.Request_Commit:
 		res := s.app.Commit()

--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -15,29 +15,12 @@ type CheckTxCallback func(types.ResponseCheckTx)
 // All methods take a RequestXxx argument and return a ResponseXxx argument,
 // except CheckTx/DeliverTx, which take `tx []byte`, and `Commit`, which takes nothing.
 type Application interface {
-	// Info/Query Connection
-	Info(types.RequestInfo) types.ResponseInfo                // Return application info
-	SetOption(types.RequestSetOption) types.ResponseSetOption // Set application option
-	Query(types.RequestQuery) types.ResponseQuery             // Query for state
+	types.Application
 
 	// Mempool Connection
-	CheckTxSync(types.RequestCheckTx) types.ResponseCheckTx      // Validate a tx for the mempool
 	CheckTxAsync(types.RequestCheckTx, CheckTxCallback)          // Asynchronously validate a tx for the mempool
 	BeginRecheckTx(RequestBeginRecheckTx) ResponseBeginRecheckTx // Signals the beginning of rechecking
 	EndRecheckTx(RequestEndRecheckTx) ResponseEndRecheckTx       // Signals the end of rechecking
-
-	// Consensus Connection
-	InitChain(types.RequestInitChain) types.ResponseInitChain    // Initialize blockchain w validators/other info from OstraconCore
-	BeginBlock(types.RequestBeginBlock) types.ResponseBeginBlock // Signals the beginning of a block
-	DeliverTx(types.RequestDeliverTx) types.ResponseDeliverTx    // Deliver a tx for full processing
-	EndBlock(types.RequestEndBlock) types.ResponseEndBlock       // Signals the end of a block, returns changes to the validator set
-	Commit() types.ResponseCommit                                // Commit the state and return the application Merkle root hash
-
-	// State Sync Connection
-	ListSnapshots(types.RequestListSnapshots) types.ResponseListSnapshots                // List available snapshots
-	OfferSnapshot(types.RequestOfferSnapshot) types.ResponseOfferSnapshot                // Offer a snapshot to the application
-	LoadSnapshotChunk(types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk    // Load a snapshot chunk
-	ApplySnapshotChunk(types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk // Apply a shapshot chunk
 }
 
 //-------------------------------------------------------
@@ -64,7 +47,7 @@ func (BaseApplication) DeliverTx(req types.RequestDeliverTx) types.ResponseDeliv
 	return types.ResponseDeliverTx{Code: types.CodeTypeOK}
 }
 
-func (BaseApplication) CheckTxSync(req types.RequestCheckTx) types.ResponseCheckTx {
+func (BaseApplication) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
 	return types.ResponseCheckTx{Code: types.CodeTypeOK}
 }
 
@@ -151,7 +134,7 @@ func (app *GRPCApplication) DeliverTx(ctx context.Context, req *types.RequestDel
 }
 
 func (app *GRPCApplication) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	res := app.app.CheckTxSync(*req)
+	res := app.app.CheckTx(*req)
 	return &res, nil
 }
 

--- a/abci/types/mocks/application.go
+++ b/abci/types/mocks/application.go
@@ -56,13 +56,8 @@ func (_m *Application) BeginRecheckTx(_a0 abcitypes.RequestBeginRecheckTx) abcit
 	return r0
 }
 
-// CheckTxAsync provides a mock function with given fields: _a0, _a1
-func (_m *Application) CheckTxAsync(_a0 types.RequestCheckTx, _a1 abcitypes.CheckTxCallback) {
-	_m.Called(_a0, _a1)
-}
-
-// CheckTxSync provides a mock function with given fields: _a0
-func (_m *Application) CheckTxSync(_a0 types.RequestCheckTx) types.ResponseCheckTx {
+// CheckTx provides a mock function with given fields: _a0
+func (_m *Application) CheckTx(_a0 types.RequestCheckTx) types.ResponseCheckTx {
 	ret := _m.Called(_a0)
 
 	var r0 types.ResponseCheckTx
@@ -73,6 +68,11 @@ func (_m *Application) CheckTxSync(_a0 types.RequestCheckTx) types.ResponseCheck
 	}
 
 	return r0
+}
+
+// CheckTxAsync provides a mock function with given fields: _a0, _a1
+func (_m *Application) CheckTxAsync(_a0 types.RequestCheckTx, _a1 abcitypes.CheckTxCallback) {
+	_m.Called(_a0, _a1)
 }
 
 // Commit provides a mock function with given fields:

--- a/rpc/client/mock/abci.go
+++ b/rpc/client/mock/abci.go
@@ -53,7 +53,7 @@ func (a ABCIApp) ABCIQueryWithOptions(
 // TODO: Make it wait for a commit and set res.Height appropriately.
 func (a ABCIApp) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	res := ctypes.ResultBroadcastTxCommit{}
-	res.CheckTx = a.App.CheckTxSync(abci.RequestCheckTx{Tx: tx})
+	res.CheckTx = a.App.CheckTx(abci.RequestCheckTx{Tx: tx})
 	if res.CheckTx.IsErr() {
 		return &res, nil
 	}
@@ -80,7 +80,7 @@ func (a ABCIApp) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.Res
 }
 
 func (a ABCIApp) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
-	c := a.App.CheckTxSync(abci.RequestCheckTx{Tx: tx})
+	c := a.App.CheckTx(abci.RequestCheckTx{Tx: tx})
 	// and this gets written in a background thread...
 	if !c.IsErr() {
 		go func() { a.App.DeliverTx(abci.RequestDeliverTx{Tx: tx}) }()


### PR DESCRIPTION
## Description

This PR changes Application interface to use Tendermint as possible. This renames `CheckTxSync` to `CheckTx` so it is required to modify application implementation.

