### PR TITLE
Remove docker building during e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,100 +8,14 @@ on:
       - main
       - release/**
 
-env:
-  TAG: ostracon/e2e-node:local-version # See test/e2e/Makefile:docker
-  CACHE_DIR: /tmp/ostracon/e2etest
-
 jobs:
-  e2e-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    outputs:
-      CACHE_FILE: ${{ steps.prep.outputs.CACHE_FILE }}
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.20'
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: technote-space/get-diff-action@v6.1.2
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
-
-      - name: Create cache directory
-        run: |
-          mkdir -p /tmp/.buildx-cache
-          mkdir -p ${{ env.CACHE_DIR }}
-
-      - name: Prepare
-        id: prep
-        run: |
-          HASH_GHE=${{ github.sha }}
-          VARIANT=$(TZ=UTC-9 date '+%Y%m')${HASH_GHE:0:7}
-          NAME_TAR="${VARIANT}.tar"
-          CACHE_FILE=${{ env.CACHE_DIR }}"/${NAME_TAR}"
-          echo "CACHE_FILE=${CACHE_FILE}" >> $GITHUB_OUTPUT
-        if: "env.GIT_DIFF != ''"
-
-      - name: Get Docker Image File from cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: ${{ steps.prep.outputs.CACHE_FILE }}
-        if: "env.GIT_DIFF != ''"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
-
-      - name: Get cached Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
-
-      - name: Build e2e Docker
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./test/e2e/docker/Dockerfile
-          tags: ${{ env.TAG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          load: true
-        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
-
-      - name: Move cached Docker layers
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
-
-      - name: Save Docker Image
-        run: |
-          docker save -o ${{ steps.prep.outputs.CACHE_FILE }} ${{ env.TAG }}
-        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
-
   e2e-test:
-    needs: e2e-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
-
+          go-version: "1.20"
       - uses: actions/checkout@v4
-
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -109,22 +23,10 @@ jobs:
             go.mod
             go.sum
 
-      - name: Get Docker Image File from cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: ${{ needs.e2e-build.outputs.CACHE_FILE }}
-        if: "env.GIT_DIFF != ''"
-
-      - name: Load Docker Image on Docker
-        run: |
-          docker load -i ${{ needs.e2e-build.outputs.CACHE_FILE }}
-        if: "env.GIT_DIFF != ''"
-
-      - name: Build e2e runner
+      - name: Build
         working-directory: test/e2e
-        run: make runner
+        # Run two make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker runner
         if: "env.GIT_DIFF != ''"
 
       - name: Run CI testnet

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+// hogehoge
+
 var (
 	// OCCoreSemVer is the current version of Ostracon Core.
 	// It's the Semantic Version of the software.

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,5 @@
 package version
 
-// hogehoge
-
 var (
 	// OCCoreSemVer is the current version of Ostracon Core.
 	// It's the Semantic Version of the software.


### PR DESCRIPTION
## Description

This PR stops caching docker image because this was for libsodium and change it to become the same as original jobs. 
original: https://github.com/tendermint/tendermint/blob/v0.34.24/.github/workflows/e2e.yml

Closes: #XXX

