### PR TITLE
fix: modify proto pubkey regisiter name for IBC relayer compatibility

### DIFF
--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -12,9 +12,9 @@ import (
 )
 
 func init() {
-	json.RegisterType((*pc.PublicKey)(nil), "ostracon.crypto.PublicKey")
-	json.RegisterType((*pc.PublicKey_Ed25519)(nil), "ostracon.crypto.PublicKey_Ed25519")
-	json.RegisterType((*pc.PublicKey_Secp256K1)(nil), "ostracon.crypto.PublicKey_Secp256K1")
+	json.RegisterType((*pc.PublicKey)(nil), "tendermint.crypto.PublicKey")
+	json.RegisterType((*pc.PublicKey_Ed25519)(nil), "tendermint.crypto.PublicKey_Ed25519")
+	json.RegisterType((*pc.PublicKey_Secp256K1)(nil), "tendermint.crypto.PublicKey_Secp256K1")
 }
 
 // PubKeyToProto takes crypto.PubKey and transforms it to a protobuf Pubkey


### PR DESCRIPTION
## Description

1. IBC relayer(hermes) parse events based on `tendermint-rs`. It renames fields as `tendermint.crypto.*` via `serde` for PublicKey. ([ref](https://github.com/informalsystems/tendermint-rs/blob/bcc0b377812b8e53a02dff156988569c5b3c81a2/tendermint/src/public_key.rs#L76))
2. To fix above issue, we should modify register name for our proto pubkey. This is only used for converting to JSON. And Ostracon doesn't save these values anywhere so there are no breaking changes even if we change this. (saved consensus key with [internal type](https://github.com/Finschia/ostracon/blob/main/crypto/ed25519/ed25519.go#L39-L41), not proto type)

Closes: #XXX

