### PR TITLE
fix: remove unnecessary condition

### DIFF
--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -5,11 +5,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/Finschia/ostracon/privval/internal"
-
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 
 	"github.com/Finschia/ostracon/libs/log"
+	"github.com/Finschia/ostracon/privval/internal"
 	"github.com/Finschia/ostracon/libs/service"
 	tmsync "github.com/Finschia/ostracon/libs/sync"
 	ocprivvalproto "github.com/Finschia/ostracon/proto/ostracon/privval"

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -2,9 +2,10 @@ package privval
 
 import (
 	"fmt"
-	"github.com/Finschia/ostracon/privval/internal"
 	"net"
 	"time"
+
+	"github.com/Finschia/ostracon/privval/internal"
 
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 
@@ -29,7 +30,7 @@ func SignerListenerEndpointTimeoutReadWrite(timeout time.Duration) SignerListene
 // connections from the only allowed addresses
 func SignerListenerEndpointAllowAddress(protocol string, allowedAddresses []string) SignerListenerEndpointOption {
 	return func(sl *SignerListenerEndpoint) {
-		if protocol == "tcp" || len(protocol) == 0 {
+		if protocol == "tcp" {
 			sl.connFilter = internal.NewIpFilter(allowedAddresses, sl.Logger)
 			return
 		}


### PR DESCRIPTION
## Description

This PR removes unnecessary condition.

## Issue

Regarding the connection side, the NewSignerListener supports the tcp and unix protocols.

https://github.com/Finschia/ostracon/blob/08c34d4f52caa73faacabcab092b6ad65a35e6c2/privval/utils.go#L29-L53

Therefore, in the context of the if statement, there should not be any instances where the protocol field is empty, indicated by `len(protocol) == 0`.

https://github.com/Finschia/ostracon/blob/08c34d4f52caa73faacabcab092b6ad65a35e6c2/privval/signer_listener_endpoint.go#L30-L38
