### PR TITLE
fix: fix incompatible type of priv_validator_raddrs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -246,10 +246,10 @@ type BaseConfig struct { //nolint: maligned
 	PrivValidatorListenAddr string `mapstructure:"priv_validator_laddr"`
 
 	// Validator's remote addresses to allow a connection
-	// Comma separated list of addresses to allow
-	// ostracon only allows a connection from these addresses separated by a comma
-	// example) 127.0.0.1
-	// example) 127.0.0.1,192.168.1.2
+	// List of addresses in TOML array format to allow
+	// ostracon only allows a connection from these listed addresses
+	// example) [ "127.0.0.1" ]
+	// example) [ "127.0.0.1", "192.168.1.2" ]
 	PrivValidatorRemoteAddresses []string `mapstructure:"priv_validator_raddrs"`
 
 	// A JSON file containing the private key to use for p2p authenticated encryption

--- a/config/toml.go
+++ b/config/toml.go
@@ -161,11 +161,11 @@ priv_validator_state_file = "{{ js .BaseConfig.PrivValidatorState }}"
 priv_validator_laddr = "{{ .BaseConfig.PrivValidatorListenAddr }}"
 
 # Validator's remote address to allow a connection
-# Comma separated list of addresses to allow
-# ostracon only allows a connection from these addresses separated by a comma
-# example) 127.0.0.1
-# example) 127.0.0.1,192.168.1.2
-priv_validator_raddrs = "127.0.0.1"
+# List of addresses in TOML array format to allow
+# ostracon only allows a connection from these listed addresses
+# example) [ "127.0.0.1" ]
+# example) [ "127.0.0.1", "192.168.1.2" ]
+priv_validator_raddrs = [ "127.0.0.1" ]
 
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node_key_file = "{{ js .BaseConfig.NodeKey }}"


### PR DESCRIPTION
## Description
This PR fix incompatible type of `priv_validator_raddrs` in TOML
The `PrivValidatorRemoteAddresses` was defined as string array, while the `priv_validator_raddrs` was of a string type rather than a slice type, which creates a mismatch with the structure of the configuration after parsing the toml file.
Related #692 & #707 

