### PR TITLE
fix: add string trim for PrivValidatorListenAddr string

### DIFF
--- a/cmd/ostracon/commands/show_validator.go
+++ b/cmd/ostracon/commands/show_validator.go
@@ -2,15 +2,16 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/Finschia/ostracon/node"
-	"github.com/Finschia/ostracon/types"
 	"github.com/spf13/cobra"
 
 	cfg "github.com/Finschia/ostracon/config"
 	tmjson "github.com/Finschia/ostracon/libs/json"
 	tmos "github.com/Finschia/ostracon/libs/os"
+	"github.com/Finschia/ostracon/node"
 	"github.com/Finschia/ostracon/privval"
+	"github.com/Finschia/ostracon/types"
 )
 
 // ShowValidatorCmd adds capabilities for showing the validator info.
@@ -24,9 +25,9 @@ var ShowValidatorCmd = &cobra.Command{
 	PreRun: deprecateSnakeCase,
 }
 
-func showValidator(cmd *cobra.Command, args []string, config *cfg.Config) error {
+func showValidator(_ *cobra.Command, _ []string, config *cfg.Config) error {
 	var pv types.PrivValidator
-	if config.PrivValidatorListenAddr != "" {
+	if strings.TrimSpace(config.PrivValidatorListenAddr) != "" {
 		chainID, err := loadChainID(config)
 		if err != nil {
 			return err

--- a/node/node.go
+++ b/node/node.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 	"strings"
 	"time"
 
@@ -52,8 +53,6 @@ import (
 	"github.com/Finschia/ostracon/types"
 	tmtime "github.com/Finschia/ostracon/types/time"
 	"github.com/Finschia/ostracon/version"
-
-	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 
 	_ "github.com/lib/pq" // provide the psql db driver
 )
@@ -124,7 +123,7 @@ func NewOstraconNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 	}
 
 	var privKey types.PrivValidator
-	if config.PrivValidatorListenAddr == "" {
+	if strings.TrimSpace(config.PrivValidatorListenAddr) == "" {
 		privKey = privval.LoadFilePV(
 			config.PrivValidatorKeyFile(),
 			config.PrivValidatorStateFile())
@@ -792,7 +791,7 @@ func NewNode(config *cfg.Config,
 
 	// If an address is provided, listen on the socket for a connection from an
 	// external signing process.
-	if config.PrivValidatorListenAddr != "" {
+	if strings.TrimSpace(config.PrivValidatorListenAddr) != "" {
 		// FIXME: we should start services inside OnStart
 		privValidator, err = CreateAndStartPrivValidatorSocketClient(config, genDoc.ChainID, logger)
 		if err != nil {


### PR DESCRIPTION
## Description

* (Audit issue) add TrimSpace for the string value of PrivValidatorListenAddr
  * Potential problem: 
    * The configuration is utilized to ascertain the remote Key Management Service (KMS) through the PrivValidatorListenAddr, which is in string format loaded from the config TOML file. However, it currently lacks a space trim.

