### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -266,7 +266,7 @@ func echoViaWS(cl *client.WSClient, val string) (string, error) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		return "", err
+		return "", msg.Error
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)


### PR DESCRIPTION
## Description

In fact, err is incorrect and should be msg.Error.

Closes: #XXX

